### PR TITLE
修正：在Electron下签名失败

### DIFF
--- a/tencentcloud/common/abstract_client.js
+++ b/tencentcloud/common/abstract_client.js
@@ -200,10 +200,10 @@ class AbstractClient {
     formatSignString(params) {
         let strParam = "";
         let keys = Object.keys(params);
-        keys.sort();
-        for (let k in keys) {
+        keys = keys.sort();
+        for (let k of keys) {
             //k = k.replace(/_/g, '.');
-            strParam += ("&" + keys[k] + "=" + params[keys[k]]);
+            strParam += ("&" + k + "=" + params[k]);
         }
         let strSign = this.profile.httpProfile.reqMethod.toLocaleUpperCase() + this.getEndpoint() +
             this.path + "?" + strParam.slice(1);


### PR DESCRIPTION
# 问题
在Electron项目中使用该SDK调用腾讯云直播API CreateCommonMixStream，返回签名失败的错误。

# 环境
* Windows 10 v2004 x64
* Node v10.21.0 x64
* Electron v6.1.12
* tencentcloud-sdk-nodejs v3.0.260

# 调试过程
经过断点调试，发现用来签名的字符串signStr的末尾有奇怪的东西，如下：
```
"POSTlive.tencentcloudapi.com/?Action=CreateCommonMixStream&InputStreamList.0.InputStreamName=xxxx_aux&InputStreamList.0.LayoutParams.ImageHeight=1080&InputStreamList.0.LayoutParams.ImageLayer=1&InputStreamList.0.LayoutParams.ImageWidth=1920&InputStreamList.0.LayoutParams.InputType=5&InputStreamList.0.LayoutParams.LocationX=0&InputStreamList.0.LayoutParams.LocationY=0&InputStreamList.1.InputStreamName=xxxx_main&InputStreamList.1.LayoutParams.ImageHeight=270&InputStreamList.1.LayoutParams.ImageLayer=2&InputStreamList.1.LayoutParams.ImageWidth=360&InputStreamList.1.LayoutParams.InputType=0&InputStreamList.1.LayoutParams.LocationX=1560&InputStreamList.1.LayoutParams.LocationY=810&Language=en-US&MixStreamSessionId=xxxx_mix&Nonce=39975&OutputParams.OutputStreamName=xxxx_mix&OutputParams.OutputStreamType=1&RequestClient=SDK_NODEJS_3.0.260&SecretId=xxxx&SignatureMethod=HmacSHA256&Timestamp=1602085151&Version=2018-08-01&function(val) { // eslint-disable-line no-extend-native
  const index = this.indexOf(val)
  if (index > -1) {
    this.splice(index, 1)
  }
}=undefined"
```
![image](https://user-images.githubusercontent.com/2238607/95358430-a1d77e80-08fb-11eb-8cc8-ef9f299255a1.png)

# 测试
该修改在当前环境中测试通过，**在其他环境下未做测试**。