### PR TITLE
chore(tsconfig): enable strictNullChecks

### DIFF
--- a/src/common/http/http_connection.ts
+++ b/src/common/http/http_connection.ts
@@ -67,13 +67,13 @@ export class HttpConnection {
     data: any
     service: string
     action: string
-    region: string
+    region: string | null
     version: string
     secretId: string
     secretKey: string
     multipart?: boolean
     timeout?: number
-    token: string
+    token: string | null
     requestClient: string
     language: string
     headers?: Record<string, string>
@@ -156,7 +156,7 @@ export class HttpConnection {
       secretId,
       secretKey,
       multipart,
-      boundary: form ? form.getBoundary() : undefined,
+      boundary: form ? form.getBoundary() : '',
     })
 
     config.headers["Authorization"] = signature

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "rootDir": "src" /* ts编译根目录. */,
     "importHelpers": true /* 从tslib导入辅助工具函数(如__importDefault)*/,
     "strict": true /* 严格模式开关 等价于noImplicitAny、strictNullChecks、strictFunctionTypes、strictBindCallApply等设置true */,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "noUnusedLocals": false /* 未使用局部变量报错*/,
     "noUnusedParameters": false /* 未使用参数报错*/,
     "noImplicitReturns": true /* 有代码路径没有返回值时报错*/,


### PR DESCRIPTION
启用 `tsconfig.json` 里的 `strictNullChecks`。

在 `strictNullChecks: true` 及 `skipLibCheck: false` 的 ts 项目里，如果这里 `strictNullChecks: false` 将导致引入 `tencentcloud-sdk-nodejs` 的项目编译失败。主要错误来自 `src/common/abstract_client.ts` 的 `interface RequestOptions extends Pick<ClientProfile["httpProfile"], "headers"> {` 类型定义。