### PR TITLE
Automatically Close Issues Using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Automatically Close Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  close_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
It's 8PM, time to leave work.
This GitHub Actions workflow automatically closes all newly opened issues, allowing Tencent Cloud employees to focus on sending legal notices to everyone involved in issue #160.